### PR TITLE
Bump Poetry to 2.3.2 and add Python 3.14 support

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -33,10 +33,10 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
           push: true
-          tags: nanomad/poetry:2.1.3-python-3.12
+          tags: nanomad/poetry:2.3.2-python-3.12
           build-args: |
             PYTHON_VERSION=3.12
-            POETRY_VERSION=2.1.3
+            POETRY_VERSION=2.3.2
 
       - name: Build and push (Python 3.13)
         uses: docker/build-push-action@v6
@@ -46,7 +46,20 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
           push: true
-          tags: nanomad/poetry:2.1.3-python-3.13
+          tags: nanomad/poetry:2.3.2-python-3.13
           build-args: |
             PYTHON_VERSION=3.13
-            POETRY_VERSION=2.1.3
+            POETRY_VERSION=2.3.2
+
+      - name: Build and push (Python 3.14)
+        uses: docker/build-push-action@v6
+        continue-on-error: false
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
+          push: true
+          tags: nanomad/poetry:2.3.2-python-3.14
+          build-args: |
+            PYTHON_VERSION=3.14
+            POETRY_VERSION=2.3.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.13
+ARG PYTHON_VERSION=3.14
 
 FROM python:${PYTHON_VERSION}-slim
 
@@ -16,7 +16,7 @@ RUN apt-get update  \
             curl \
     && rm -rf /var/lib/apt/lists/*
 
-ARG POETRY_VERSION=2.1.3
+ARG POETRY_VERSION=2.3.2
 ENV POETRY_VERSION=${POETRY_VERSION}
 ENV POETRY_HOME=/opt/poetry
 ENV POETRY_NO_INTERACTION=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   poetry-armv7:
-    image: nanomad/poetry:2.1.3-python-3.12
+    image: nanomad/poetry:2.3.2-python-3.12
     build:
       context: .
     platform: linux/arm/v7
@@ -8,7 +8,7 @@ services:
     command:
       - poetry --version
   poetry-arm64v8:
-    image: nanomad/poetry:2.1.3-python-3.12
+    image: nanomad/poetry:2.3.2-python-3.12
     build:
       context: .
     platform: linux/arm64/v8
@@ -16,7 +16,7 @@ services:
     command:
       - poetry --version
   poetry-amd64:
-    image: nanomad/poetry:2.1.3-python-3.12
+    image: nanomad/poetry:2.3.2-python-3.12
     build:
       context: .
     platform: linux/amd64


### PR DESCRIPTION
## Summary
- Bump Poetry from 2.1.3 to 2.3.2 in Dockerfile, docker-compose.yml, and CI workflow
- Add Python 3.14 build target to the CI pipeline (alongside existing 3.12 and 3.13)
- Update Dockerfile default Python version from 3.13 to 3.14

## Test plan
- [ ] Verify CI workflow triggers and builds all 3 Python versions (3.12, 3.13, 3.14)
- [ ] Verify Poetry 2.3.2 installs correctly on all platforms (amd64, arm64, armv7)
- [ ] Verify pushed images work with `poetry --version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)