### PR TITLE
Split multi-arch builds into per-platform parallel jobs

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -8,17 +8,26 @@ on:
 
 env:
   POETRY_VERSION: "2.3.2"
+  IMAGE_NAME: nanomad/poetry
 
 jobs:
-  build-and-push:
+  build:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         python-version: ["3.12", "3.13", "3.14"]
+        platform:
+          - linux/amd64
+          - linux/arm64/v8
+          - linux/arm/v7
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+
+      - name: Set platform tag suffix
+        id: platform
+        run: echo "slug=$(echo '${{ matrix.platform }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
 
       - name: Login to DockerHub
         uses: docker/login-action@v3
@@ -32,14 +41,36 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push (Python ${{ matrix.python-version }})
+      - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64/v8,linux/arm/v7
+          platforms: ${{ matrix.platform }}
           push: true
-          tags: nanomad/poetry:${{ env.POETRY_VERSION }}-python-${{ matrix.python-version }}
+          provenance: false
+          tags: ${{ env.IMAGE_NAME }}:${{ env.POETRY_VERSION }}-python-${{ matrix.python-version }}-${{ steps.platform.outputs.slug }}
           build-args: |
             PYTHON_VERSION=${{ matrix.python-version }}
             POETRY_VERSION=${{ env.POETRY_VERSION }}
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13", "3.14"]
+    steps:
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Create multi-arch manifest
+        run: |
+          docker buildx imagetools create -t \
+            ${{ env.IMAGE_NAME }}:${{ env.POETRY_VERSION }}-python-${{ matrix.python-version }} \
+            ${{ env.IMAGE_NAME }}:${{ env.POETRY_VERSION }}-python-${{ matrix.python-version }}-linux-amd64 \
+            ${{ env.IMAGE_NAME }}:${{ env.POETRY_VERSION }}-python-${{ matrix.python-version }}-linux-arm64-v8 \
+            ${{ env.IMAGE_NAME }}:${{ env.POETRY_VERSION }}-python-${{ matrix.python-version }}-linux-arm-v7


### PR DESCRIPTION
## Summary
- Split the build matrix from 3 jobs (python × 3 sequential platforms) into 9 parallel jobs (python × platform)
- Each job builds a single platform, pushing a platform-specific tag (e.g., `2.3.2-python-3.13-linux-arm64-v8`)
- A merge job combines platform tags into the final multi-arch manifest (e.g., `2.3.2-python-3.13`)
- Wall time drops from sum of all platform builds to just the slowest single platform

## Test plan
- [ ] Verify all 9 build jobs run in parallel
- [ ] Verify the 3 merge jobs create correct multi-arch manifests
- [ ] Verify `docker manifest inspect nanomad/poetry:2.3.2-python-3.{12,13,14}` shows all 3 platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)