### PR TITLE
Bump GitHub Actions to Node 24 versions

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -23,26 +23,26 @@ jobs:
           - linux/arm/v7
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set platform tag suffix
         id: platform
         run: echo "slug=$(echo '${{ matrix.platform }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
 
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -62,7 +62,7 @@ jobs:
         python-version: ["3.12", "3.13", "3.14"]
     steps:
       - name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Bump all GitHub Actions to their latest major versions with Node 24 support
- `actions/checkout` v4 → v6
- `docker/build-push-action` v6 → v7
- `docker/login-action` v3 → v4
- `docker/setup-qemu-action` v3 → v4
- `docker/setup-buildx-action` v3 → v4

Resolves the Node.js 20 deprecation warnings before the June 2026 deadline.

## Test plan
- [ ] Verify CI workflow runs without Node.js deprecation warnings
- [ ] Verify all build and merge jobs complete successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)